### PR TITLE
all job-related queries and mutations now automatically reload after …

### DIFF
--- a/client/src/components/ComLog/index.jsx
+++ b/client/src/components/ComLog/index.jsx
@@ -3,7 +3,7 @@ import {ADD_COMLOG} from '../../utils/mutations';
 import {useMutation} from "@apollo/client";
 import UpdateComLog from "../UpdateComLog"
 import {DELETE_COMLOG} from '../../utils/mutations';
-
+import {QUERY_JOB} from '../../utils/queries';
 
 const ComLog = ({ comLogs = [], jobId }) => {
   const [method, setMethod] = useState("");
@@ -11,8 +11,14 @@ const ComLog = ({ comLogs = [], jobId }) => {
   const [direction, setDirection] = useState("");
   const [updatedComLogId, setUpdatedComLogId] = useState(null);
 
-  const [addComLog, { error }] = useMutation(ADD_COMLOG);
-  const [deleteComLog] = useMutation(DELETE_COMLOG);
+  const [addComLog, { error }] = useMutation(ADD_COMLOG, {refetchQueries: [
+    QUERY_JOB,
+    'job'
+  ]});
+  const [deleteComLog] = useMutation(DELETE_COMLOG, {refetchQueries: [
+    QUERY_JOB,
+    'job'
+  ]});
 
 
   const handleComLogUpdate = (_id) => {

--- a/client/src/components/ContactPersonForm/index.jsx
+++ b/client/src/components/ContactPersonForm/index.jsx
@@ -2,6 +2,8 @@ import { useState } from "react";
 import { Link } from "react-router-dom";
 import { useMutation } from "@apollo/client";
 import { ADD_CONTACT_PERSON } from "../../utils/mutations";
+import { QUERY_JOB } from "../../utils/queries";
+
 
 import Auth from "../../utils/auth";
 
@@ -12,7 +14,10 @@ const ContactPersonForm = ({jobId}) => {
   const [email, setContactPersonEmail] = useState("");
   const [notes, setContactPersonNotes] = useState("");
 
-  const [addContactPerson, { error }] = useMutation(ADD_CONTACT_PERSON);
+  const [addContactPerson, { error }] = useMutation(ADD_CONTACT_PERSON, {refetchQueries: [
+    QUERY_JOB,
+    'job'
+  ]});
 
   const handleFormSubmit = async (event) => {
     event.preventDefault();

--- a/client/src/components/Job/index.jsx
+++ b/client/src/components/Job/index.jsx
@@ -13,7 +13,10 @@ const Job = ({ jobId }) => {
   const [addContactPersonButton, setAddContactPersonButton] = useState(false);
  
   const [updatedContactId, setUpdatedContactId] = useState(null);
-  const [deleteContact] = useMutation(DELETE_CONTACT_PERSON);
+  const [deleteContact] = useMutation(DELETE_CONTACT_PERSON, {refetchQueries: [
+    QUERY_JOB,
+    'job'
+  ]});
 
   const handleContactUpdate = (_id) => {
     setUpdatedContactId(_id);

--- a/client/src/components/JobForm/index.jsx
+++ b/client/src/components/JobForm/index.jsx
@@ -2,6 +2,8 @@ import { useState } from "react";
 import { Link } from "react-router-dom";
 import { useMutation } from "@apollo/client";
 import { ADD_JOB } from "../../utils/mutations";
+import { QUERY_ME } from "../../utils/queries";
+
 
 import Auth from "../../utils/auth";
 
@@ -11,7 +13,11 @@ const JobForm = () => {
   const [advertisedSalary, setAdvertisedSalary] = useState("");
   const [offerMade, setOfferMade] = useState(false);
 
-  const [addJob, { error }] = useMutation(ADD_JOB);
+  const [addJob, { error }] = useMutation(ADD_JOB, {refetchQueries: [
+    QUERY_ME,
+    'me'
+
+  ]});
 
   const handleFormSubmit = async (event) => {
     event.preventDefault();

--- a/client/src/components/UpdateComLog/index.jsx
+++ b/client/src/components/UpdateComLog/index.jsx
@@ -1,13 +1,18 @@
 import { useState } from "react";
 import { UPDATE_COMLOG } from "../../utils/mutations";
 import { useMutation } from "@apollo/client";
+import { QUERY_JOB } from "../../utils/queries";
+
 
 const UpdateComLog = ({ _id }) => {
   const [method, setMethod] = useState("");
   const [content, setContent] = useState("");
   const [direction, setDirection] = useState("");
 
-  const [updateComLog, { error }] = useMutation(UPDATE_COMLOG);
+  const [updateComLog, { error }] = useMutation(UPDATE_COMLOG, {refetchQueries: [
+    QUERY_JOB,
+    'job'
+  ]});
 
   const handleFormSubmit = async (event) => {
     event.preventDefault();

--- a/client/src/components/UpdateContactPersonForm/index.jsx
+++ b/client/src/components/UpdateContactPersonForm/index.jsx
@@ -2,6 +2,8 @@ import { useState } from "react";
 import { Link } from "react-router-dom";
 import { useMutation } from "@apollo/client";
 import { UPDATE_CONTACT_PERSON } from "../../utils/mutations";
+import { QUERY_JOB } from "../../utils/queries";
+
 
 import Auth from "../../utils/auth";
 
@@ -12,7 +14,10 @@ const UpdateContactPersonForm = ({_id}) => {
   const [email, setContactPersonEmail] = useState("");
   const [notes, setContactPersonNotes] = useState("");
 
-  const [updateContactPerson, { error }] = useMutation(UPDATE_CONTACT_PERSON);
+  const [updateContactPerson, { error }] = useMutation(UPDATE_CONTACT_PERSON, {refetchQueries: [
+    QUERY_JOB,
+    'job'
+  ]});
 
   const handleFormSubmit = async (event) => {
     event.preventDefault();

--- a/client/src/components/UpdateJobForm/index.jsx
+++ b/client/src/components/UpdateJobForm/index.jsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Link } from "react-router-dom";
 import { useMutation } from "@apollo/client";
 import { UPDATE_JOB } from "../../utils/mutations";
+import { QUERY_ME } from "../../utils/queries";
 
 import Auth from "../../utils/auth";
 //Need to pass jobId in as a prop
@@ -11,7 +12,10 @@ const UpdateJobForm = ({jobId}) => {
   const [advertisedSalary, setAdvertisedSalary] = useState("");
   const [offerMade, setOfferMade] = useState(false);
 
-  const [updateJob, { error }] = useMutation(UPDATE_JOB);
+  const [updateJob, { error }] = useMutation(UPDATE_JOB, {refetchQueries: [
+    QUERY_ME,
+    'me'
+  ]});
 
   const handleFormSubmit = async (event) => {
     event.preventDefault();

--- a/client/src/pages/JobTracker.jsx
+++ b/client/src/pages/JobTracker.jsx
@@ -14,7 +14,10 @@ const JobTracker = () => {
   const [addButton, setAddButton] = useState(false);
   const [selectedJobId, setSelectedJobId] = useState(null);
   const [updatedJobId, setUpdatedJobId] = useState(null);
-  const [deleteJob] = useMutation(DELETE_JOB);
+  const [deleteJob] = useMutation(DELETE_JOB, {refetchQueries: [
+    QUERY_ME,
+    'me'
+  ]});
 
   const handleJobClick = (jobId) => {
     setSelectedJobId(jobId);


### PR DESCRIPTION
…data is submitted